### PR TITLE
Add error handling and keys storage

### DIFF
--- a/PhantomConnectExample/PhantomConnectExample/ContentView.swift
+++ b/PhantomConnectExample/PhantomConnectExample/ContentView.swift
@@ -8,16 +8,24 @@
 import SwiftUI
 import Solana
 import PhantomConnect
+import Foundation
 
 struct ContentView: View {
     
     @StateObject var viewModel = PhantomConnectViewModel()
     
-    @State var walletConnected = false
+    /// Saving keys in appstorage(user defaults).
+    /// THIS IS NOT SECURE! FOR DEMO ONLY!
+    /// Keychain can be used as a ssecure storage
+    @AppStorage("k_wallet_connected") var walletConnected = false
+    @AppStorage("k_wallet_public_key") var walletPublicKeyB58: String?
+    @AppStorage("k_wallet_phantom_encryption_key") var phantomEncryptionKeyB58: String?
     @State var walletPublicKey: PublicKey?
     @State var phantomEncryptionKey: PublicKey?
-    @State var session: String?
+    @AppStorage("k_wallet_phantom_session") var session: String?
     @State var transactionSignature: String?
+    
+    @State var balance_Sol: Double?
     
     var body: some View {
         
@@ -32,6 +40,12 @@ struct ContentView: View {
                     redirectUrl: "example://"
                 )
                 
+                
+                if let pubkey = self.walletPublicKeyB58, let enckey = self.phantomEncryptionKeyB58  {
+                    self.walletPublicKey = PublicKey(string: pubkey)
+                    self.phantomEncryptionKey = PublicKey(string: enckey)
+                }
+                self.getWalletAndBalance()
             }
         
     }
@@ -60,6 +74,11 @@ struct ContentView: View {
             self.phantomEncryptionKey = phantomEncryptionPublicKey
             self.session = session
             
+            self.walletPublicKeyB58 = self.walletPublicKey?.base58EncodedString
+            self.phantomEncryptionKeyB58 = self.phantomEncryptionKey?.base58EncodedString
+            
+            self.getWalletAndBalance()
+            
             walletConnected.toggle()
             
         }
@@ -68,10 +87,14 @@ struct ContentView: View {
     
     var connectedContent: some View {
         
-        VStack(spacing: 24) {
+        VStack(spacing: 30) {
+            
+            
+            Text("Balance: \(self.balance_Sol ?? 0) SOL")
+            
             
             VStack {
-                Text("Wallet Public Key:")
+                Text("Wallet:")
                 Text(walletPublicKey?.base58EncodedString ?? "--")
             }
             
@@ -125,10 +148,11 @@ struct ContentView: View {
             .onWalletTransaction(
                 phantomEncryptionPublicKey: phantomEncryptionKey,
                 dappEncryptionSecretKey: viewModel.linkingKeypair?.secretKey
-            ) { signature, _ in
+            ) { signature, error in
                 
                 transactionSignature = signature
-                
+                self.getWalletAndBalance()
+                print("Error(onWalletTransaction): \(String(describing: error))")
             }
             
             Button {
@@ -139,6 +163,13 @@ struct ContentView: View {
                     session: session,
                     dappSecretKey: viewModel.linkingKeypair?.secretKey
                 )
+                
+                self.walletPublicKey = nil
+                self.phantomEncryptionKey = nil
+                self.walletPublicKeyB58 = nil
+                self.phantomEncryptionKeyB58 = nil
+                //walletConnected.toggle()
+                
                 
             } label: {
                 
@@ -177,6 +208,8 @@ struct ContentView: View {
             
             let serializedTransaction = try? transaction.serialize().get()
             
+            print("Transaction:", transaction)
+            
             DispatchQueue.main.async {
                 completion(Base58.encode(serializedTransaction!.bytes))
             }
@@ -185,6 +218,21 @@ struct ContentView: View {
         
     }
     
+    func getWalletAndBalance(){
+        guard let publicKey = self.walletPublicKey else {
+            return
+        }
+        
+        let solana = Solana(router: NetworkingRouter(endpoint: .devnetSolana))
+        
+        solana.api.getAccountInfo(account: publicKey.base58EncodedString, decodedTo: AccountInfo.self) { result in
+            try? print("Account: \(result.get())")
+        }
+        solana.api.getBalance(account: publicKey.base58EncodedString){ result in
+            try? print("Balance: \(Double(result.get()) / 1000000000) SOL")
+            try? self.balance_Sol = Double(result.get()) / 1000000000
+        }
+    }
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/PhantomConnectExample/PhantomConnectExample/ContentView.swift
+++ b/PhantomConnectExample/PhantomConnectExample/ContentView.swift
@@ -84,13 +84,36 @@ struct ContentView: View {
                 
                 createTransaction { serializedTransaction in
                     
-                    try? viewModel.sendAndSignTransaction(
-                        serializedTransaction: serializedTransaction,
-                        dappEncryptionKey: viewModel.linkingKeypair?.publicKey,
-                        phantomEncryptionKey: phantomEncryptionKey,
-                        session: session,
-                        dappSecretKey: viewModel.linkingKeypair?.secretKey
-                    )
+                    do {
+                        try viewModel.sendAndSignTransaction(
+                            serializedTransaction: serializedTransaction,
+                            dappEncryptionKey: viewModel.linkingKeypair?.publicKey,
+                            phantomEncryptionKey: phantomEncryptionKey,
+                            session: session,
+                            dappSecretKey: viewModel.linkingKeypair?.secretKey
+                        )
+                    }
+                    catch PhantomConnectError.invalidConfiguration{
+                        print("Error:", PhantomConnectError.invalidConfiguration)
+                    }
+                    catch PhantomConnectError.invalidDappSecretKey{
+                        print("Error:", PhantomConnectError.invalidDappSecretKey)
+                    }
+                    catch PhantomConnectError.invalidEncryptionPublicKey{
+                        print("Error:", PhantomConnectError.invalidEncryptionPublicKey)
+                    }
+                    catch PhantomConnectError.invalidSerializedTransaction{
+                        print("Error:", PhantomConnectError.invalidSerializedTransaction)
+                    }
+                    catch PhantomConnectError.invalidUrl{
+                        print("Error:", PhantomConnectError.invalidUrl)
+                    }
+                    catch PhantomConnectError.missingSharedSecret{
+                        print("Error:", PhantomConnectError.missingSharedSecret.description)
+                    }
+                    catch {
+                        print("Error: Unknown")
+                    }
                     
                 }
                 

--- a/Sources/PhantomConnect/Models/PhantomConnectError.swift
+++ b/Sources/PhantomConnect/Models/PhantomConnectError.swift
@@ -14,6 +14,7 @@ public enum PhantomConnectError: Error {
     case invalidSerializedTransaction
     case invalidConfiguration
     case invalidUrl
+    case missingSharedSecret
     
 }
 
@@ -36,6 +37,9 @@ extension PhantomConnectError: CustomStringConvertible {
                 
             case .invalidUrl:
                 return "Invalid URL"
+            
+            case .missingSharedSecret:
+                return "Phantom says 'Missing shared secret'. Something went wrong within Phantom. Either selected not correct wallet in phantom or session expired by phantom. Try to disconnect and connect to Phantom again."
                 
         }
         
@@ -76,6 +80,12 @@ extension PhantomConnectError: LocalizedError {
                 return NSLocalizedString(
                     "Invalid URL",
                     comment: "Invalid URL"
+                )
+            
+            case .missingSharedSecret:
+                return NSLocalizedString(
+                    "Phantom says 'Missing shared secret'. Something went wrong within Phantom. Either selected not correct wallet in phantom or session expired by phantom.",
+                    comment: "Missing Shared Secret"
                 )
                 
         }

--- a/Sources/PhantomConnect/Services/PhantomUrlHandler.swift
+++ b/Sources/PhantomConnect/Services/PhantomUrlHandler.swift
@@ -65,9 +65,13 @@ public class PhantomUrlHandler {
         var error: Error?
         
         if components.queryItems?[0].name == "errorCode" {
-                        
-            error = PhantomConnectError.invalidUrl
-            
+            if components.queryItems?[0].value == "-32603" {
+                //errorCode=-32603&errorMessage=Missing+shared+secret
+                error = PhantomConnectError.missingSharedSecret
+            }
+            else {
+                error = PhantomConnectError.invalidUrl
+            }
         }
         
         switch host {

--- a/Sources/PhantomConnect/Views/PhantomConnectViewModel.swift
+++ b/Sources/PhantomConnect/Views/PhantomConnectViewModel.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 import Solana
-
+import SwiftUI
 #if os(iOS)
 import UIKit
 #endif
 
-@available(iOS 13.0, macOS 10.15, *)
+@available(iOS 14.0, macOS 10.15, *)
 public class PhantomConnectViewModel: ObservableObject {
     
     // ============================================================
@@ -22,7 +22,13 @@ public class PhantomConnectViewModel: ObservableObject {
     // MARK: - Public API
     
     // MARK: Public Properties
-   
+
+    /// Saving keys in appstorage(user defaults).
+    /// THIS IS NOT SECURE! FOR DEMO ONLY!
+    /// Keychain can be used as a ssecure storage
+    @AppStorage("k_dap_secret_key") var secretKey: Data?
+    @AppStorage("k_encryption_pub_key") var publicKey: String?
+    
     /// Initial keypair used for connecting with phantom. This property should only be counted on being present during the app session where connection was made, unless manually set.
     public var linkingKeypair: BoxedKeypair?
     
@@ -37,12 +43,26 @@ public class PhantomConnectViewModel: ObservableObject {
     /// - Parameter phantomConnectService: Dependency injected service
     public init(phantomConnectService: PhantomConnectService? = PhantomConnectService()) {
         self.phantomConnectService = phantomConnectService!
+        
+        if let dapSecKey = self.secretKey, let pubKey = self.publicKey {
+            self.linkingKeypair = BoxedKeypair(
+                publicKey: PublicKey(string: pubKey) ?? PublicKey(bytes: PublicKey.NULL_PUBLICKEY_BYTES)!,
+                secretKey: dapSecKey
+            )
+        }
     }
     
     /// This method kicks the app over to the  phantom app via a universal link created in the `PhantomConnectService`
     public func connectWallet() throws {
         
         linkingKeypair = try SolanaUtils.generateBoxedKeypair()
+        
+        /// Saving keys in appstorage(user defaults).
+        /// THIS IS NOT SECURE! FOR DEMO ONLY!
+        /// Keychain can be used as a ssecure storage
+        self.secretKey = linkingKeypair?.secretKey
+        self.publicKey = linkingKeypair?.publicKey.base58EncodedString
+        
     
         let url = try phantomConnectService.connect(
             publicKey: linkingKeypair?.publicKey.data ?? Data()


### PR DESCRIPTION
I used this package in my project and made some additions mainly for error handling. 

- Added `errorCode=-32603&errorMessage=Missing+shared+secret` error handling 
- Added keys storing into `@AppStorage` for convenience 

Hope this will be useful. 

p.s. I will continue to add integration and handling of all error codes listed here: https://docs.phantom.app/integrating/errors 